### PR TITLE
Make live-reload work with --inline mode

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,7 +28,7 @@ const config = {
   output: {
     filename: "[name].js",
     path: path.join(__dirname, "./build"),
-    publicPath: "/",
+    publicPath: "/build",
   },
   plugins: [
     new ExtractTextPlugin("[name].css"),


### PR DESCRIPTION
In order for live-reload to work, requests going to webpack bundles (e.g. app.css, app.js) should be handled by webpack-dev-server. This could be done by setting output.publicPath to `"/build"`.

With this change, running `webpack-dev-server --inline` will detect changes in source files and reload the page automatically.