### PR TITLE
fix(): more flexible paths to assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <title>Webpack CSS example</title>
-    <link rel="stylesheet" href="/build/app.css" />
+    <link rel="stylesheet" href="build/app.css" />
   </head>
   <body>
     <div id="main"></div>
-    <script src="/build/app.js"></script>
+    <script src="build/app.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Allow the assets to be loaded whether opening the index via file path or via a local server.

Resolves issue: https://github.com/bensmithett/webpack-css-example/issues/18