### PR TITLE
Webpakc Config use resolve.root

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,7 +40,7 @@ const config = {
   ],
   resolve: {
     extensions: ['', '.js', '.sass'],
-    modulesDirectories: ['src', 'node_modules']
+    root: [path.join(__dirname, './src')]
   }
 }
 


### PR DESCRIPTION
Using the webpack option `resolve.root` is more appropriate than changing `resolve.modulesDirectories`.

[Documentation](https://webpack.github.io/docs/configuration.html#resolve-root)